### PR TITLE
[sync] add --dry-run flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+tmp/


### PR DESCRIPTION
adds a `--dry-run` flag so users can validate their configs

example:
```
❯ go run effx.go sync --dry-run -d ../backeffx
2020/02/06 14:06:22 parsing ../backeffx/deploy/k8s/post/ambassador-backeffx.yaml
2020/02/06 14:06:22 ../backeffx/deploy/k8s/post/ambassador-backeffx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/deploy/k8s/prod/ambassador-backeffx.yaml
2020/02/06 14:06:22 ../backeffx/deploy/k8s/prod/ambassador-backeffx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/effx.yaml
2020/02/06 14:06:22 ../backeffx/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/bacta/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/bacta/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/bodo/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/bodo/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/dooku/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/dooku/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/dreadnought/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/dreadnought/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/droideka/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/droideka/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/effervescing/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/effervescing/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/effort/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/effort/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/effx.yaml
2020/02/06 14:06:22 ../backeffx/services/effx.yaml is valid
2020/02/06 14:06:22 parsing ../backeffx/services/kamino/effx.yaml
2020/02/06 14:06:22 error: yaml: unmarshal errors:
  line 10: cannot unmarshal !!str `tedryn` into data.Service
  line 11: cannot unmarshal !!str `watto` into data.Service
  line 12: cannot unmarshal !!str `kos` into data.Service
  line 13: cannot unmarshal !!str `bacta` into data.Service
exit status 1
```