### PR TITLE
[event] add a create command

### DIFF
--- a/cmd/effx.go
+++ b/cmd/effx.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/effxhq/effx-go/cmd/event"
 	"github.com/effxhq/effx-go/cmd/sync"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +21,10 @@ var rootCmd = &cobra.Command{
 
 func Initialize() {
 	sync.Initialize()
+	event.Initialize()
+
 	rootCmd.AddCommand(sync.SyncCmd)
+	rootCmd.AddCommand(event.EventCreateCmd)
 }
 
 func Execute() {

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -1,0 +1,108 @@
+package event
+
+import (
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/effxhq/effx-go/data"
+	"github.com/effxhq/effx-go/internal/client/http"
+	"github.com/effxhq/effx-go/internal/validator"
+	"github.com/spf13/cobra"
+)
+
+const effxApiKeyName = "EFFX_API_KEY"
+
+var (
+	apiKeyString             string
+	nameString               string
+	descriptionString        string
+	serviceNameString        string
+	integrationNameString    string
+	integrationVersionString string
+	userEmailString          string
+	tagsString               string
+	hashtagsString           string
+)
+
+func Initialize() {
+	EventCreateCmd.PersistentFlags().StringVarP(&apiKeyString, "key", "k", "", "your effx api key. alternatively, you can use env var EFFX_API_KEY")
+	EventCreateCmd.PersistentFlags().StringVarP(&nameString, "name", "", "", "name of your event")
+	EventCreateCmd.PersistentFlags().StringVarP(&descriptionString, "desc", "", "", "name of your event")
+	EventCreateCmd.PersistentFlags().StringVarP(&serviceNameString, "service", "", "", "name of service")
+	EventCreateCmd.PersistentFlags().StringVarP(&userEmailString, "user", "", "", "email for current user")
+	EventCreateCmd.PersistentFlags().StringVarP(&integrationNameString, "integration_name", "", "", "name of integration")
+	EventCreateCmd.PersistentFlags().StringVarP(&integrationVersionString, "integration_version", "", "", "version of integration")
+	EventCreateCmd.PersistentFlags().StringVarP(&tagsString, "tags", "t", "", "tags in the format of k:v . use commas to separate tags")
+	EventCreateCmd.PersistentFlags().StringVarP(&hashtagsString, "hashtags", "", "", "hashtags. use commas to separate hashtags")
+}
+
+var EventCreateCmd = &cobra.Command{
+	Use:   "event create",
+	Short: "create an event via the effx api",
+	Long:  `create an event via the effx api`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if apiKeyString == "" {
+			if apiKeyString = os.Getenv(effxApiKeyName); apiKeyString == "" {
+				log.Fatal("api key is required")
+			}
+		}
+
+		tags := []*data.Tag{}
+		hashtags := []string{}
+
+		if tagsString != "" {
+			tagsStringNoSpace := strings.Join(strings.Fields(tagsString), "")
+			splitTagsString := strings.Split(tagsStringNoSpace, ",")
+
+			for _, splitTag := range splitTagsString {
+				splitTagString := strings.Split(splitTag, ":")
+
+				if len(splitTagString) == 2 {
+					tags = append(tags, &data.Tag{Key: splitTagString[0], Value: splitTagString[1]})
+				} else {
+					log.Fatalf("found invalid tag: %s", splitTag)
+				}
+			}
+		}
+
+		if hashtagsString != "" {
+			hashtagsStringNoSpace := strings.Join(strings.Fields(tagsString), "")
+			hashtags = strings.Split(hashtagsStringNoSpace, ",")
+		}
+
+		c := http.New(apiKeyString)
+
+		object := &data.Data{
+			Tap: &data.Tap{
+				ProducedAtTimeMilliseconds: time.Now().UnixNano() / 1e6,
+				Name:                       nameString,
+				Description:                descriptionString,
+				Tags:                       tags,
+				Hashtags:                   hashtags,
+				Integration: &data.Integration{
+					Name:    integrationNameString,
+					Version: integrationVersionString,
+				},
+				Service: &data.Service{
+					Name: serviceNameString,
+				},
+			},
+		}
+
+		if userEmailString != "" {
+			object.Tap.User = &data.User{
+				Email: userEmailString,
+			}
+		}
+
+		if err := validator.ValidateObject(object); err != nil {
+			log.Fatal(err.Error())
+		}
+
+		if err := c.Synchronize(object); err != nil {
+			log.Fatal(err.Error())
+		}
+	},
+}

--- a/data/data.go
+++ b/data/data.go
@@ -2,6 +2,7 @@ package data
 
 type Data struct {
 	Service *Service
+	Tap     *Tap
 }
 
 type Link struct {
@@ -33,4 +34,24 @@ type Service struct {
 	Email          *Link      `json:"email"`
 	Runbook        *Link      `json:"runbook"`
 	VersionControl *Link      `json:"version_control" yaml:"version_control"`
+}
+
+type Tap struct {
+	Name                       string `validate:"required"`
+	Description                string `validate:"required"`
+	ProducedAtTimeMilliseconds int64  `json:"produced_at_time_milliseconds" validate:"required"`
+	Tags                       []*Tag
+	Hashtags                   []string
+	Integration                *Integration `validate:"required"`
+	Service                    *Service     `validate:"required"`
+	User                       *User
+}
+
+type Integration struct {
+	Name    string `validate:"required"`
+	Version string `validate:"required"`
+}
+
+type User struct {
+	Email string `validate:"required"`
 }


### PR DESCRIPTION
example:
```bash
EFFX_API_KEY=safds go run effx.go event create --name=hello \
                                               --service=world \
                                               --desc="this is anevent" \
                                               --integration_name=deployboard \
                                               --integration_version="1" \
                                               --tags="hello:world" \
                                               --user=will@effx.com \
                                               --hashtags="blah,go"
```

help:
```
❯ go run effx.go event create --help
create an event via the effx api

Usage:
  effx event create [flags]

Flags:
      --desc string                  name of your event
      --hashtags string              hashtags. use commas to separate hashtags
  -h, --help                         help for event
      --integration_name string      name of integration
      --integration_version string   version of integration
  -k, --key string                   your effx api key. alternatively, you can use env var EFFX_API_KEY
      --name string                  name of your event
      --service string               name of service
  -t, --tags string                  tags in the format of k:v . use commas to separate tags
      --user string                  email for current user
```