### PR TITLE
[Makefile] fix TAG variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ORG		 := effx
 APP    := effx-cli
 NAME   := ${ORG}/${APP}
-TAG    := $$(git tag --points-at HEAD)
+TAG    := $$(git rev-parse --short HEAD)
 IMG    := ${NAME}:${TAG}
 LATEST := ${NAME}:latest
 


### PR DESCRIPTION
`git tag --points-at HEAD` returned nothing, so fixing so that it's the same as the other Makefiles for generating tags