### PR TITLE
add env var to configure api host

### DIFF
--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -98,7 +98,19 @@ var EventCreateCmd = &cobra.Command{
 				Email: userEmailString,
 			}
 		}
-		client := effx_api.NewAPIClient(effx_api.NewConfiguration())
+
+		basePath := "https://api.effx.io/v1"
+
+		if os.Getenv("EFFX_API_HOST") != "" {
+			log.Printf("switching to use basePath %s", fmt.Sprintf("%s/v1", os.Getenv("EFFX_API_HOST")))
+			basePath = fmt.Sprintf("%s/v1", os.Getenv("EFFX_API_HOST"))
+		}
+
+		client := effx_api.NewAPIClient(&effx_api.Configuration{
+			BasePath:      basePath,
+			DefaultHeader: make(map[string]string),
+			UserAgent:     "Swagger-Codegen/1.0.0/go",
+		})
 
 		_, err := client.EventsApi.EventsPut(
 			context.Background(),

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -93,7 +93,18 @@ func processFile(filePath string) error {
 
 		log.Printf("sending %s to effx api", filePath)
 
-		client := effx_api.NewAPIClient(effx_api.NewConfiguration())
+		basePath := "https://api.effx.io/v1"
+
+		if os.Getenv("EFFX_API_HOST") != "" {
+			log.Printf("switching to use basePath %s", fmt.Sprintf("%s/v1", os.Getenv("EFFX_API_HOST")))
+			basePath = fmt.Sprintf("%s/v1", os.Getenv("EFFX_API_HOST"))
+		}
+
+		client := effx_api.NewAPIClient(&effx_api.Configuration{
+			BasePath:      basePath,
+			DefaultHeader: make(map[string]string),
+			UserAgent:     "Swagger-Codegen/1.0.0/go",
+		})
 
 		for _, obj := range objects {
 			if obj.Service != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.2.6"
+const Version = "v0.2.7"


### PR DESCRIPTION
add environment variable `EFFX_API_HOST` to allow us to configure some events to go to post environment.