### PR TITLE
Goreleaser CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 jobs:
   lint:
@@ -24,8 +25,21 @@ jobs:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+  release:
+    docker:
+      - image: circleci/golang:1.15
+    steps:
+      - checkout
+      - run: curl -sL https://git.io/goreleaser | bash
 workflows:
   version: 2
   build-workflow:
     jobs:
       - lint
+      - release:
+          context: effx-cli-releases
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # vendor/
 
 tmp/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - go mod download
+    - go mod verify
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+blobs:
+  - provider: s3
+    region: us-west-2
+    bucket: effx-cli
+    folder: "releases/{{ .Version }}"
+  - provider: s3
+    region: us-west-2
+    bucket: effx-cli
+    folder: "releases/latest"
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: md5
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
## What
 - Adds https://goreleaser.com/intro/ to our CI workflow
 - When a tag is created (must follow vX.X.X semantic versioning), a set of binaries will get created and get added to the project's "Releases". These releases are accessible by those with access to the repository.
 - These same artifacts are pushed to a public S3 bucket, where customers can pull from

## Why
So we can share our CLI in binary form 