### PR TITLE
Effx Yaml Pattern Allows effx.yaml

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -19,7 +19,7 @@ type EffxYaml struct {
 }
 
 func (y EffxYaml) getFilePattern() string {
-	return `.+\.effx\.(yaml|yml)$`
+	return "(.+\\.)?effx\\.ya?ml$"
 }
 
 func (y EffxYaml) isEffxYaml() (bool, error) {


### PR DESCRIPTION
## What
- CLI now allows `effx.yaml` and `*.effx.yaml` file patterns