### PR TITLE
detect services

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"errors"
+	"log"
 	"os"
 
 	"github.com/effxhq/effx-cli/internal/parser"
@@ -52,7 +53,9 @@ var SyncCmd = &cobra.Command{
 			}
 		}
 
-		parser.DetectServicesFromEffxYamls(resources, apiKeyString, "effx-cli")
+		err := parser.DetectServicesFromEffxYamls(resources, apiKeyString, "effx-cli")
+		log.Println("Could not send detected services, err:", err)
+
 		return nil
 	},
 }

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -46,15 +46,17 @@ var SyncCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resources := parser.ProcessArgs(filePathString, directoryString)
 
+		err := parser.DetectServicesFromEffxYamls(resources, apiKeyString, "effx-cli")
+		if err != nil {
+			log.Println("Could not send detected services, err:", err)
+		}
+
 		for _, resource := range resources {
 			err := resource.Sync(apiKeyString)
 			if err != nil {
 				return err
 			}
 		}
-
-		err := parser.DetectServicesFromEffxYamls(resources, apiKeyString, "effx-cli")
-		log.Println("Could not send detected services, err:", err)
 
 		return nil
 	},

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -51,6 +51,8 @@ var SyncCmd = &cobra.Command{
 				return err
 			}
 		}
+
+		parser.DetectServicesFromEffxYamls(resources, apiKeyString, "effx-cli")
 		return nil
 	},
 }

--- a/data/data.go
+++ b/data/data.go
@@ -65,7 +65,7 @@ func (y EffxYaml) Lint() error {
 	}
 	body, _ := json.Marshal(config)
 
-	url := generateURL()
+	url := GenerateUrl()
 	url.Path = "v2/config/lint"
 
 	resp, err := http.Post(url.String(), "application/json", bytes.NewReader(body))
@@ -87,7 +87,7 @@ func (y EffxYaml) Sync(apiKey string) error {
 	}
 	body, _ := json.Marshal(config)
 
-	url := generateURL()
+	url := GenerateUrl()
 	url.Path = "v2/config"
 
 	request, _ := http.NewRequest("PUT", url.String(), bytes.NewReader(body))
@@ -110,7 +110,7 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
-func generateURL() *url.URL {
+func GenerateUrl() *url.URL {
 	u := url.URL{
 		Scheme: "https",
 		Host:   getEnv(EffxAPIHost, "api.effx.io"),

--- a/data/event_data.go
+++ b/data/event_data.go
@@ -19,7 +19,7 @@ func (y EffxEvent) SendEvent(apiKey string) error {
 
 	log.Printf("Sending event payload %+v\n", string(body))
 
-	url := generateURL()
+	url := GenerateUrl()
 	url.Path = "v2/events"
 
 	request, _ := http.NewRequest("POST", url.String(), bytes.NewReader(body))

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/effxhq/effx-cli
 go 1.13
 
 require (
-	github.com/effxhq/effx-api-v2/generated/go/client v0.0.0-20210128153249-b1f5a0eea5ab
+	github.com/effxhq/effx-api-v2/generated/go/client v0.0.0-20210217201049-ab6505970c62
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.4.0
+	github.com/thoas/go-funk v0.7.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/oauth2 v0.0.0-20210126194326-f9ce19ea3013 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/effxhq/effx-api-v2/generated/go/client v0.0.0-20210128153249-b1f5a0eea5ab h1:hZbzLmIE3h8BGGKUVC1vqdTOiTk6w7FyXHdCFvJg/sg=
 github.com/effxhq/effx-api-v2/generated/go/client v0.0.0-20210128153249-b1f5a0eea5ab/go.mod h1:8jVqAfklB8MqGZyUfMvReuQZwTB+OJlR6ytlOYg3Zg8=
+github.com/effxhq/effx-api-v2/generated/go/client v0.0.0-20210217201049-ab6505970c62 h1:yZrZGl7cJv/0TDjcun6asfEsriIgMa/FADXTKu16wWc=
+github.com/effxhq/effx-api-v2/generated/go/client v0.0.0-20210217201049-ab6505970c62/go.mod h1:8jVqAfklB8MqGZyUfMvReuQZwTB+OJlR6ytlOYg3Zg8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -142,7 +142,10 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/thoas/go-funk v0.7.0 h1:GmirKrs6j6zJbhJIficOsz2aAI7700KsU/5YrdHRM1Y=
+github.com/thoas/go-funk v0.7.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -1,0 +1,87 @@
+package discover
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func findCommonDirectory(effxFileLocations []string) string {
+	matchedEffxFiles := generateIterators(effxFileLocations)
+	prefixString := ""
+
+	for len(matchedEffxFiles) > 0 {
+		count := make(map[string]int)
+		for _, matchedFile := range matchedEffxFiles {
+			peek := matchedFile.Peek()
+			if peek != "" {
+				count[peek]++
+			}
+		}
+
+		maxK := ""
+		maxV := 1
+		for k, v := range count {
+			if v > maxV {
+				maxK = k
+				maxV = v
+			}
+		}
+
+		nextRound := make([]*Iterator, 0, maxV)
+		for _, matchedFile := range matchedEffxFiles {
+			// advance ptr
+			if matchedFile.Next() == maxK {
+				// put into next
+				nextRound = append(nextRound, matchedFile)
+			}
+		}
+
+		prefixString += maxK
+		matchedEffxFiles = nextRound
+
+	}
+
+	if prefixString == "" {
+		return ""
+	}
+
+	// prefix string should be a directory ending with a slash
+	slashIndex := strings.LastIndex(prefixString, "/")
+
+	if slashIndex != len(prefixString) {
+		// trim file name, keep last dir slash
+		// example:
+		// services/dooku -> services/
+		prefixString = prefixString[:slashIndex+1]
+	}
+
+	return prefixString
+}
+
+func DetectServices(effxFileLocations []string) []string {
+	detectedServiceNames := []string{}
+
+	commonDir := findCommonDirectory(effxFileLocations)
+
+	files, err := ioutil.ReadDir(commonDir)
+	if err != nil {
+		return []string{}
+	}
+
+	for _, file := range files {
+		// looking at directories only for service locations
+		if file.IsDir() {
+			contains := false
+			for _, effxFileLocation := range effxFileLocations {
+				if strings.Contains(effxFileLocation, file.Name()) {
+					contains = true
+				}
+			}
+			if !contains {
+				detectedServiceNames = append(detectedServiceNames, file.Name())
+			}
+		}
+	}
+
+	return detectedServiceNames
+}

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	effx_api "github.com/effxhq/effx-api-v2/generated/go/client"
-	"github.com/effxhq/effx-cli/data"
 )
 
 func findCommonDirectory(effxFileLocations []string) string {
@@ -93,7 +93,7 @@ func DetectServices(effxFileLocations []string) []string {
 	return detectedServiceNames
 }
 
-func SendDetectedServices(apiKey, sourceName string, services []string) error {
+func SendDetectedServices(apiKey, sourceName string, url *url.URL, services []string) error {
 	for _, serviceName := range services {
 		payload := effx_api.DetectedServicesPayload{
 			Name:       serviceName,
@@ -101,7 +101,6 @@ func SendDetectedServices(apiKey, sourceName string, services []string) error {
 		}
 		body, _ := json.Marshal(payload)
 
-		url := data.GenerateUrl()
 		url.Path = "v2/detected_services"
 
 		request, _ := http.NewRequest("PUT", url.String(), bytes.NewReader(body))
@@ -114,5 +113,7 @@ func SendDetectedServices(apiKey, sourceName string, services []string) error {
 		}
 		defer resp.Body.Close()
 	}
+
+	log.Println("Succesfully detected ", len(services), " services"))
 	return nil
 }

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -95,6 +95,7 @@ func DetectServices(effxFileLocations []string) []string {
 }
 
 func SendDetectedServices(apiKey, sourceName string, url *url.URL, services []string) error {
+
 	for _, serviceName := range services {
 		payload := effx_api.DetectedServicesPayload{
 			Name:       serviceName,
@@ -115,6 +116,6 @@ func SendDetectedServices(apiKey, sourceName string, url *url.URL, services []st
 		defer resp.Body.Close()
 	}
 
-	log.Println("Successfully detected ", len(services), " services")
+	log.Println("Successfully detected ", len(services), " service(s)")
 	return nil
 }

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -115,6 +115,6 @@ func SendDetectedServices(apiKey, sourceName string, url *url.URL, services []st
 		defer resp.Body.Close()
 	}
 
-	log.Println("Succesfully detected ", len(services), " services")
+	log.Println("Successfully detected ", len(services), " services")
 	return nil
 }

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -114,6 +115,6 @@ func SendDetectedServices(apiKey, sourceName string, url *url.URL, services []st
 		defer resp.Body.Close()
 	}
 
-	log.Println("Succesfully detected ", len(services), " services"))
+	log.Println("Succesfully detected ", len(services), " services")
 	return nil
 }

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -1,0 +1,29 @@
+package discover_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/effxhq/effx-cli/internal/discover"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumer_SetupFS(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "services")
+	defer os.RemoveAll(dir)
+
+	dooku, _ := ioutil.TempDir(dir, "dooku")
+	tedryn, _ := ioutil.TempDir(dir, "tedryn")
+	_, _ = ioutil.TempDir(dir, "watto")
+
+	tedrynFile, _ := ioutil.TempFile(tedryn, "effx.yaml")
+	wattoFile, _ := ioutil.TempFile(dooku, "effx.yaml")
+
+	input := []string{tedrynFile.Name(), wattoFile.Name()}
+
+	res := discover.DetectServices(input)
+
+	require.Len(t, res, 1)
+	require.Contains(t, res[0], "watto")
+}

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConsumer_SetupFS(t *testing.T) {
+func Test_Discover_Services(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "services")
 	defer os.RemoveAll(dir)
 

--- a/internal/discover/iterator.go
+++ b/internal/discover/iterator.go
@@ -1,0 +1,37 @@
+package discover
+
+func New(val string) *Iterator {
+	return &Iterator{val: val}
+}
+
+type Iterator struct {
+	ptr int
+	val string
+}
+
+func (i Iterator) HasNext() bool {
+	return i.ptr < len(i.val)
+}
+
+func (i *Iterator) Peek() string {
+	if !i.HasNext() {
+		return ""
+	}
+	return i.val[i.ptr : i.ptr+1]
+}
+
+func (i *Iterator) Next() string {
+	v := i.Peek()
+	i.ptr++
+	return v
+}
+
+func generateIterators(list []string) []*Iterator {
+	result := []*Iterator{}
+
+	for _, s := range list {
+		result = append(result, New(s))
+	}
+
+	return result
+}

--- a/internal/parser/process.go
+++ b/internal/parser/process.go
@@ -10,6 +10,7 @@ import (
 
 	effx_api "github.com/effxhq/effx-api-v2/generated/go/client"
 	"github.com/effxhq/effx-cli/data"
+	"github.com/effxhq/effx-cli/internal/discover"
 )
 
 type EventPayload struct {
@@ -56,6 +57,8 @@ func ProcessDirectory(directory string) []data.EffxYaml {
 	for _, path := range matches {
 		yamls = append(yamls, data.EffxYaml{FilePath: path})
 	}
+
+	discover.DetectServices(matches)
 
 	return yamls
 }

--- a/internal/parser/process.go
+++ b/internal/parser/process.go
@@ -70,13 +70,12 @@ func DetectServicesFromEffxYamls(files []data.EffxYaml, apiKeyString, sourceName
 
 	services := discover.DetectServices(filePaths)
 
-	return discover.SendDetectedServices(apiKeyString, sourceName, services)
+	return discover.SendDetectedServices(apiKeyString, sourceName, data.GenerateUrl(), services)
 }
 
 func ProcessEvent(e *EventPayload) *data.EffxEvent {
 	tagsPayload := []effx_api.CreateEventPayloadTags{}
 	actions := []effx_api.CreateEventPayloadActions{}
-	timestampMilliseconds := time.Now().Unix() * 1000
 	producedAtTime := int64(e.ProducedAtTimeMS)
 
 	if len(e.Tags) > 0 {
@@ -111,20 +110,19 @@ func ProcessEvent(e *EventPayload) *data.EffxEvent {
 		}
 	}
 
-	// if optional produced at timstamp is less than a year ago.
-	if producedAtTime > time.Now().AddDate(-1, 0, 0).UnixNano()/1e6 {
-		timestampMilliseconds = producedAtTime
-	}
-
 	payload := &data.EffxEvent{
 		Payload: &effx_api.CreateEventPayload{
-			Title:                 e.Title,
-			Message:               e.Message,
-			ServiceName:           &e.ServiceName,
-			Tags:                  &tagsPayload,
-			Actions:               &actions,
-			TimestampMilliseconds: &timestampMilliseconds,
+			Title:       e.Title,
+			Message:     e.Message,
+			ServiceName: &e.ServiceName,
+			Tags:        &tagsPayload,
+			Actions:     &actions,
 		},
+	}
+
+	// if optional produced at timstamp is less than a year ago.
+	if producedAtTime > time.Now().AddDate(-1, 0, 0).UnixNano()/1e6 {
+		payload.Payload.TimestampMilliseconds = &producedAtTime
 	}
 
 	return payload

--- a/internal/parser/process.go
+++ b/internal/parser/process.go
@@ -58,9 +58,19 @@ func ProcessDirectory(directory string) []data.EffxYaml {
 		yamls = append(yamls, data.EffxYaml{FilePath: path})
 	}
 
-	discover.DetectServices(matches)
-
 	return yamls
+}
+
+func DetectServicesFromEffxYamls(files []data.EffxYaml, apiKeyString, sourceName string) error {
+	filePaths := []string{}
+
+	for _, file := range files {
+		filePaths = append(filePaths, file.FilePath)
+	}
+
+	services := discover.DetectServices(filePaths)
+
+	return discover.SendDetectedServices(apiKeyString, sourceName, services)
 }
 
 func ProcessEvent(e *EventPayload) *data.EffxEvent {
@@ -113,7 +123,7 @@ func ProcessEvent(e *EventPayload) *data.EffxEvent {
 			ServiceName:           &e.ServiceName,
 			Tags:                  &tagsPayload,
 			Actions:               &actions,
-			TimestampMilliseconds: timestampMilliseconds,
+			TimestampMilliseconds: &timestampMilliseconds,
 		},
 	}
 


### PR DESCRIPTION
based on where current `effx.yaml` files are found, it will attempt to deduce where other services are, and send these back to the API. 

- for example, in our backeffx dir, if a service was added (`ghost`) in `services/` and did not contain an `effx.yaml` this payload would be sent to the API. 

`
{
   "name": "ghost",
   "sourceName": "effx-cli",
}
`


- I added a test file so we can see how this works, and test edgecases. 