### PR TITLE
directory string bug fix

### DIFF
--- a/discover/discover.go
+++ b/discover/discover.go
@@ -147,7 +147,7 @@ func SendDetectedServices(apiKey string, url *url.URL, servicePayloads []effx_ap
 	return nil
 }
 
-// DetectServices (DEPRECATED) is an endpoint to detect services
+// Deprecated: DetectServices is an endpoint to detect services
 func DetectServices(sourceName string, effxFileLocations []string) []effx_api.DetectedServicesPayload {
 	detectedServices := []effx_api.DetectedServicesPayload{}
 

--- a/discover/discover_test.go
+++ b/discover/discover_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func Test_Discover_Services(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "fakedir")
+	dir := "fakedir"
+	_ = os.Mkdir(dir, 0755)
+	_, _ = os.Create(dir + "/package.json")
 	defer os.RemoveAll(dir)
 
-	_, _ = os.Create(dir + "/package.json")
-
-	res, err := discover.DetectServicesFromFiles(dir+"/", []data.EffxYaml{}, "effx-cli")
+	res, err := discover.DetectServicesFromFiles(dir, []data.EffxYaml{}, "effx-cli")
 
 	require.Nil(t, err)
 	require.Len(t, res, 1)

--- a/discover/discover_test.go
+++ b/discover/discover_test.go
@@ -1,7 +1,6 @@
 package discover_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -24,10 +23,10 @@ func Test_Discover_Services(t *testing.T) {
 }
 
 func Test_Nested_DirectoryName(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "apps")
+	dir := "apps"
+	_ = os.Mkdir(dir, 0755)
+	_ = os.Mkdir(dir+"/dooku", 0755)
 	defer os.RemoveAll(dir)
-
-	_, _ = ioutil.TempDir(dir, "dooku")
 
 	res, err := discover.DetectServicesFromFiles(dir, []data.EffxYaml{}, "effx-cli")
 

--- a/discover/discover_test.go
+++ b/discover/discover_test.go
@@ -16,7 +16,7 @@ func Test_Discover_Services(t *testing.T) {
 
 	_, _ = os.Create(dir + "/package.json")
 
-	res, err := discover.DetectServicesFromFiles(dir, []data.EffxYaml{}, "effx-cli")
+	res, err := discover.DetectServicesFromFiles(dir+"/", []data.EffxYaml{}, "effx-cli")
 
 	require.Nil(t, err)
 	require.Len(t, res, 1)

--- a/discover/infer.go
+++ b/discover/infer.go
@@ -38,9 +38,19 @@ func getInferredServiceDirectoryNames() []string {
 	return defaultInferredServiceDirectoryNames
 }
 
+func safeDirectoryString(workdir string) string {
+	slashIndex := strings.LastIndex(workdir, "/")
+
+	if slashIndex != len(workdir)-1 {
+		return workdir + "/"
+	}
+	return workdir
+}
+
 // DetectServicesFromFiles detects services based on
 // containing a service-like file (package.json etc)
 func DetectServicesFromFiles(workdir string, effxFiles []data.EffxYaml, sourceName string) ([]effx_api.DetectedServicesPayload, error) {
+	workdir = safeDirectoryString(workdir)
 	detectedServices := []effx_api.DetectedServicesPayload{}
 	effxFileLocations := filePathsFromEffxYaml(effxFiles)
 


### PR DESCRIPTION
I noticed it wouldn't detect services if you passed in a directory string without a slash
`go run effx.go sync -d ../effx-client  -k $EFFX_API_KEY` 
versus
`go run effx.go sync -d ../effx-client/  -k $EFFX_API_KEY`

plus used a more standard depreciated comment for a function