### PR TITLE
bug fix for git path

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -156,7 +156,7 @@ func (y EffxYaml) newConfig() (*effx_api.ConfigurationFile, error) {
 		relativePath = y.FilePath
 	}
 
-	versionControlUrl := getVersionControlLink(relativePath)
+	versionControlUrl := getVersionControlLink(y.FilePath, relativePath)
 
 	config.FileContents = string(yamlFile)
 	config.SetAnnotations(map[string]string{

--- a/data/url.go
+++ b/data/url.go
@@ -19,8 +19,8 @@ func getRepoName(url string) string {
 	return result[2]
 }
 
-func getVersionControlLink(relativePath string) string {
-	r, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+func getVersionControlLink(absolutePath, relativePath string) string {
+	r, err := git.PlainOpenWithOptions(absolutePath, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
- allows effx cli to look for git paths without being in the directory
- running `go run effx.go sync -d ../backeffx  -k $EFFX_API_KEY` 
outputs `https://github.com/effxhq/backeffx/edit/master/effx.yaml`
 `https://github.com/effxhq/backeffx/edit/master/services/wupiupi/effx.yaml` etc